### PR TITLE
prevent creating duplicate indices for every face

### DIFF
--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -771,8 +771,10 @@ void glTF2Importer::InternReadFile(const std::string& pFile, aiScene* pScene, IO
 
     // TODO: it does not split the loaded vertices, should it?
     //pScene->mFlags |= AI_SCENE_FLAGS_NON_VERBOSE_FORMAT;
-    MakeVerboseFormatProcess process;
-    process.Execute(pScene);
+
+    //GVRf: not splitting vertices after import
+    //MakeVerboseFormatProcess process;
+    //process.Execute(pScene);
 
 
     if (pScene->mNumMeshes == 0) {


### PR DESCRIPTION
fixes the problem with the absence of flag JOIN_IDENTICAL_VERTICES in getRecommendedMorphSettings in this [PR](https://github.com/gearvrf/GearVRf-Demos/pull/627)